### PR TITLE
Set default Vagrant machine name as PredictionIO

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "ubuntu/trusty64"
+  config.vm.define "PredictionIO"
 
   # The URL that the configured box can be found at.
   # If the box is not installed on the system, it will be retrieved from this URL when vagrant up is run.


### PR DESCRIPTION
`default` is not a meaningful machine name and
can cause confusion if the user has multiple
vagrant machines.